### PR TITLE
implement unmount process

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -28,6 +28,7 @@ export default function Editor() {
     );
     applicationRef.current = app;
     app.ccCanvas.addBlock(new CCBlock({ x: 0, y: 0 }));
+    return () => app.destroy();
   }, []);
 
   return (

--- a/src/models/application.ts
+++ b/src/models/application.ts
@@ -52,4 +52,8 @@ export default class CCApplication {
       pixiContainer: this.#pixiApplication.stage,
     });
   }
+
+  destroy() {
+    this.ccCanvas.destroy();
+  }
 }

--- a/src/models/canvas.ts
+++ b/src/models/canvas.ts
@@ -171,4 +171,9 @@ export default class CCCanvas {
       },
     });
   }
+
+  destroy() {
+    this.#pixiCanvas.removeChildren();
+    this.#pixiWorld.removeChildren();
+  }
 }


### PR DESCRIPTION
The Unmount process was implemented to avoid problems caused by useEffect being executed twice due to React's strict mode in the development environment.