### PR TITLE
World can only be moved when ctrl is pressed.

### DIFF
--- a/src/models/canvas.ts
+++ b/src/models/canvas.ts
@@ -74,10 +74,13 @@ export default class CCCanvas {
           .multiplyScalar(1 / this.worldPerspective.scale);
         switch (this.#dragState.target.type) {
           case "world":
-            this.worldPerspective = {
-              center: this.#dragState.target.initialCenter.subtract(dragOffset),
-              scale: this.worldPerspective.scale,
-            };
+            if (e.ctrlKey) {
+              this.worldPerspective = {
+                center:
+                  this.#dragState.target.initialCenter.subtract(dragOffset),
+                scale: this.worldPerspective.scale,
+              };
+            }
             return;
           case "block":
             this.#dragState.target.block.position =


### PR DESCRIPTION
To do the wiring, it was necessary to prevent the world from moving on a drag operation when ctrl was not pressed, so it was changed that way.