### PR TITLE
Refactor node layout to use relative offsets and add play-mode guards

### DIFF
--- a/src/pages/edit/Editor/components/NodePinPropertyEditor.tsx
+++ b/src/pages/edit/Editor/components/NodePinPropertyEditor.tsx
@@ -8,7 +8,7 @@ import { CCConnectionStore } from "../../../../store/connection";
 import { IntrinsicComponentDefinition } from "../../../../store/intrinsics/base";
 import { CCNodePinStore } from "../../../../store/nodePin";
 import { useStore } from "../../../../store/react";
-import getCCComponentEditorRendererNodeGeometry from "../renderer/Node/geometry";
+import { getCCComponentEditorRendererNodeGeometry } from "../renderer/Node/geometry";
 import { useComponentEditorStore } from "../store";
 
 export function CCComponentEditorNodePinPropertyEditor() {
@@ -123,33 +123,22 @@ export function CCComponentEditorNodePinPropertyEditor() {
 									nodePin.id,
 								);
 								for (const connection of connections) {
-									const anotherNodePinId =
-										connection.from === nodePin.id
-											? connection.to
-											: connection.from;
-									const fromNodePinId =
-										connection.from === nodePin.id
-											? nodePin.id
-											: anotherNodePinId;
-									const toNodePinId =
-										connection.from === nodePin.id
-											? anotherNodePinId
-											: nodePin.id;
+									const from = connection.from;
+									const to = connection.to;
 									const parentComponentId = connection.parentComponentId;
-									store.connections.unregister([connection.id]);
-									if (
-										store.nodePins.isConnectable(nodePin.id, anotherNodePinId)
-									) {
-										// reconnect if still connectable after bit width change
-										store.connections.register(
-											CCConnectionStore.create({
-												parentComponentId,
-												from: fromNodePinId,
-												to: toNodePinId,
-												bentPortion: 0.5,
-											}),
-										);
-									}
+									store.connections.unregister([connection.id]).then(() => {
+										if (store.nodePins.isConnectable(from, to)) {
+											// reconnect if still connectable after bit width change
+											store.connections.register(
+												CCConnectionStore.create({
+													parentComponentId,
+													from,
+													to,
+													bentPortion: 0.5,
+												}),
+											);
+										}
+									});
 								}
 							}
 							continue;

--- a/src/pages/edit/Editor/components/NodePinPropertyEditor.tsx
+++ b/src/pages/edit/Editor/components/NodePinPropertyEditor.tsx
@@ -169,31 +169,32 @@ export function CCComponentEditorNodePinPropertyEditor() {
 					})}
 				</Stack>
 				<Stack direction="row" gap={1} sx={{ mt: 1 }}>
-					{componentPinAttributes.isSplittable && (
-						<>
-							<Button
-								type="button"
-								variant="outlined"
-								size="small"
-								onClick={() => {
-									setNewBitWidthList([...bitWidthList, 1]);
-								}}
-							>
-								Add
-							</Button>
-							<Button
-								type="button"
-								variant="outlined"
-								size="small"
-								disabled={bitWidthList.length <= 1}
-								onClick={() => {
-									setNewBitWidthList(bitWidthList.slice(0, -1));
-								}}
-							>
-								Remove
-							</Button>
-						</>
-					)}
+					{componentPinAttributes.bitWidthPolicy.type === "configurable" &&
+						componentPinAttributes.bitWidthPolicy.isSplittable && (
+							<>
+								<Button
+									type="button"
+									variant="outlined"
+									size="small"
+									onClick={() => {
+										setNewBitWidthList([...bitWidthList, 1]);
+									}}
+								>
+									Add
+								</Button>
+								<Button
+									type="button"
+									variant="outlined"
+									size="small"
+									disabled={bitWidthList.length <= 1}
+									onClick={() => {
+										setNewBitWidthList(bitWidthList.slice(0, -1));
+									}}
+								>
+									Remove
+								</Button>
+							</>
+						)}
 					<Button
 						type="submit"
 						variant="contained"

--- a/src/pages/edit/Editor/components/ViewModeSwitcher.tsx
+++ b/src/pages/edit/Editor/components/ViewModeSwitcher.tsx
@@ -1,9 +1,12 @@
 import { Edit, PlayArrow } from "@mui/icons-material";
 import { Fab } from "@mui/material";
+import { isEachInputPinConnected } from "../../../../store/component";
+import { useStore } from "../../../../store/react";
 import { useComponentEditorStore } from "../store";
 
 export default function CCComponentEditorViewModeSwitcher() {
 	const componentEditorState = useComponentEditorStore()();
+	const { store } = useStore();
 
 	return (
 		<Fab
@@ -15,6 +18,9 @@ export default function CCComponentEditorViewModeSwitcher() {
 				);
 				componentEditorState.setTimeStep(0);
 			}}
+			disabled={
+				!isEachInputPinConnected(store, componentEditorState.componentId)
+			}
 		>
 			{componentEditorState.editorMode === "edit" ? <PlayArrow /> : <Edit />}
 		</Fab>

--- a/src/pages/edit/Editor/components/ViewModeSwitcher.tsx
+++ b/src/pages/edit/Editor/components/ViewModeSwitcher.tsx
@@ -1,12 +1,11 @@
 import { Edit, PlayArrow } from "@mui/icons-material";
 import { Fab } from "@mui/material";
-import { isEachInputPinConnected } from "../../../../store/component";
-import { useStore } from "../../../../store/react";
+import { useCanSimulate } from "../../../../store/react/selectors";
 import { useComponentEditorStore } from "../store";
 
 export default function CCComponentEditorViewModeSwitcher() {
 	const componentEditorState = useComponentEditorStore()();
-	const { store } = useStore();
+	const canSimulate = useCanSimulate(componentEditorState.componentId);
 
 	return (
 		<Fab
@@ -18,9 +17,7 @@ export default function CCComponentEditorViewModeSwitcher() {
 				);
 				componentEditorState.setTimeStep(0);
 			}}
-			disabled={
-				!isEachInputPinConnected(store, componentEditorState.componentId)
-			}
+			disabled={!canSimulate}
 		>
 			{componentEditorState.editorMode === "edit" ? <PlayArrow /> : <Edit />}
 		</Fab>

--- a/src/pages/edit/Editor/renderer/ComponentPin/index.tsx
+++ b/src/pages/edit/Editor/renderer/ComponentPin/index.tsx
@@ -30,10 +30,10 @@ export default function CCComponentEditorRendererComponentPin({
 					label: stringifySimulationValue(
 						type === "input"
 							? nullthrows(
-									componentEditorState.getInputValue([
-										interfaceComponentPin.id,
-										componentEditorState.timeStep,
-									]),
+									componentEditorState.getInputValue({
+										componentPinId: interfaceComponentPin.id,
+										timeStep: componentEditorState.timeStep,
+									}),
 								)
 							: nullthrows(componentEditorState.getNodePinValue(nodePinId)),
 					),
@@ -41,13 +41,16 @@ export default function CCComponentEditorRendererComponentPin({
 						type === "input"
 							? () => {
 									const nodePinValue = nullthrows(
-										componentEditorState.getInputValue([
-											interfaceComponentPin.id,
-											componentEditorState.timeStep,
-										]),
+										componentEditorState.getInputValue({
+											componentPinId: interfaceComponentPin.id,
+											timeStep: componentEditorState.timeStep,
+										}),
 									);
 									componentEditorState.setInputValue(
-										[interfaceComponentPin.id, componentEditorState.timeStep],
+										{
+											componentPinId: interfaceComponentPin.id,
+											timeStep: componentEditorState.timeStep,
+										},
 										wrappingIncrementSimulationValue(nodePinValue),
 									);
 								}

--- a/src/pages/edit/Editor/renderer/ComponentPin/index.tsx
+++ b/src/pages/edit/Editor/renderer/ComponentPin/index.tsx
@@ -5,7 +5,7 @@ import { useStore } from "../../../../../store/react";
 import { wrappingIncrementSimulationValue } from "../../../../../store/simulation";
 import { useComponentEditorStore } from "../../store";
 import { stringifySimulationValue } from "../../store/slices/core";
-import getCCComponentEditorRendererNodeGeometry from "./../Node/geometry";
+import { getCCComponentEditorRendererNodeGeometry } from "./../Node/geometry";
 export type CCComponentEditorRendererComponentPinProps = {
 	nodePinId: CCNodePinId;
 };

--- a/src/pages/edit/Editor/renderer/Connection/index.tsx
+++ b/src/pages/edit/Editor/renderer/Connection/index.tsx
@@ -9,7 +9,7 @@ import ensureStoreItem from "../../../../../store/react/error";
 import { useNode } from "../../../../../store/react/selectors";
 import { useComponentEditorStore } from "../../store";
 import { stringifySimulationValue } from "../../store/slices/core/index";
-import getCCComponentEditorRendererNodeGeometry from "../Node/geometry";
+import { getCCComponentEditorRendererNodeGeometry } from "../Node/geometry";
 
 export type CCComponentEditorRendererConnectionEndpoint = {
 	direction: CCComponentPinType;

--- a/src/pages/edit/Editor/renderer/Node/components/Const/geometry.ts
+++ b/src/pages/edit/Editor/renderer/Node/components/Const/geometry.ts
@@ -1,0 +1,24 @@
+import nullthrows from "nullthrows";
+import { type Vector2, vector2 } from "../../../../../../../common/vector2";
+import type { CCNodePinId } from "../../../../../../../store/nodePin";
+import type {
+	CCComponentEditorRendererNodeLayout,
+	CCComponentEditorRendererNodeLayoutSource,
+} from "../../types";
+
+export const ccComponentEditorRendererNodeConstLayoutConstants = {
+	padding: 8,
+	gridSize: 12,
+	gridSizeDisplayWidth: 60,
+};
+
+export function ccComponentRendererNodeConstLayoutCalculator(
+	source: CCComponentEditorRendererNodeLayoutSource,
+): CCComponentEditorRendererNodeLayout {
+	return {
+		size: vector2.create(400, 100),
+		nodePinOffsetById: new Map<CCNodePinId, Vector2>([
+			[nullthrows(source.outputNodePinIds[0]), vector2.create(400, 50)],
+		]),
+	};
+}

--- a/src/pages/edit/Editor/renderer/Node/components/Const/index.tsx
+++ b/src/pages/edit/Editor/renderer/Node/components/Const/index.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+import type { CCIntrinsicComponentConstSpec } from "../../../../../../../store/intrinsics/types";
+import type { CCComponentEditorRendererNodeRendererProps } from "../../types";
+import { CCComponentEditorRendererNodeDefaultRenderer } from "../Default";
+import { ccComponentEditorRendererNodeConstLayoutConstants as constants } from "./geometry";
+
+export function CCComponentEditorRendererNodeConstRenderer(
+	props: CCComponentEditorRendererNodeRendererProps,
+) {
+	const config = props.node.config as CCIntrinsicComponentConstSpec["config"];
+	const sampleData = useMemo(
+		() => Array.from({ length: config.data.length }, () => Math.random() < 0.5),
+		[config.data],
+	);
+
+	return (
+		<>
+			<CCComponentEditorRendererNodeDefaultRenderer {...props} />
+			<foreignObject
+				x={constants.padding}
+				y={constants.padding}
+				width={props.geometry.rect.size.x - constants.padding * 2}
+				height={props.geometry.rect.size.y - constants.padding * 2}
+			>
+				<table>
+					<tbody>
+						{Array(Math.ceil(config.data.length / 8))
+							.fill(null)
+							.map((_, rowIndex) => (
+								// biome-ignore lint/suspicious/noArrayIndexKey: temporary workaround
+								<tr key={rowIndex}>
+									{Array(8)
+										.fill(null)
+										.map((_, colIndex) => {
+											const index = rowIndex * 8 + colIndex;
+											if (index >= config.data.length) return null;
+											return (
+												<td
+													// biome-ignore lint/suspicious/noArrayIndexKey: temporary workaround
+													key={colIndex}
+													style={{
+														width: constants.gridSize,
+														height: constants.gridSize,
+														backgroundColor: sampleData[index]
+															? "black"
+															: "white",
+														border: "1px solid black",
+													}}
+												/>
+											);
+										})}
+								</tr>
+							))}
+					</tbody>
+				</table>
+			</foreignObject>
+		</>
+	);
+}

--- a/src/pages/edit/Editor/renderer/Node/components/Default/geometry.ts
+++ b/src/pages/edit/Editor/renderer/Node/components/Default/geometry.ts
@@ -1,50 +1,41 @@
-import { type Vector2, vector2 } from "../../../../../../../common/vector2";
+import type { Vector2 } from "../../../../../../../common/vector2";
 import type { CCNodePinId } from "../../../../../../../store/nodePin";
 import type {
-	CCComponentEditorRendererNodeGeometryCalculator,
-	CCComponentEditorRendererNodeGeometrySource,
+	CCComponentEditorRendererNodeLayout,
+	CCComponentEditorRendererNodeLayoutSource,
 } from "../../types";
 
 const width = 100;
 const gapY = 20;
 const paddingY = 15;
 
-export const ccComponentRendererNodeDefaultGeometryCalculator: CCComponentEditorRendererNodeGeometryCalculator =
-	(source: CCComponentEditorRendererNodeGeometrySource) => {
-		const size: Vector2 = {
-			x: width,
-			y:
-				gapY *
-					Math.max(
-						source.inputNodePinIds.length,
-						source.outputNodePinIds.length,
-					) +
-				paddingY * 2,
-		};
-
-		const nodePinPositionById = new Map<CCNodePinId, Vector2>();
-		for (const [index, nodePinId] of source.inputNodePinIds.entries()) {
-			nodePinPositionById.set(nodePinId, {
-				x: source.position.x - size.x / 2,
-				y:
-					source.position.y +
-					gapY * (index - source.inputNodePinIds.length / 2 + 0.5),
-			});
-		}
-		for (const [index, nodePinId] of source.outputNodePinIds.entries()) {
-			nodePinPositionById.set(nodePinId, {
-				x: source.position.x + size.x / 2,
-				y:
-					source.position.y +
-					gapY * (index - source.outputNodePinIds.length / 2 + 0.5),
-			});
-		}
-
-		return {
-			rect: {
-				position: vector2.sub(source.position, vector2.div(size, 2)),
-				size,
-			},
-			nodePinPositionById,
-		};
+export function ccComponentRendererNodeDefaultLayoutCalculator(
+	source: CCComponentEditorRendererNodeLayoutSource,
+): CCComponentEditorRendererNodeLayout {
+	const size: Vector2 = {
+		x: width,
+		y:
+			gapY *
+				Math.max(
+					source.inputNodePinIds.length,
+					source.outputNodePinIds.length,
+				) +
+			paddingY * 2,
 	};
+
+	const nodePinOffsetById = new Map<CCNodePinId, Vector2>();
+
+	const startYIn =
+		size.y / 2 - (gapY * (source.inputNodePinIds.length - 1)) / 2;
+	for (const [index, pinId] of source.inputNodePinIds.entries()) {
+		nodePinOffsetById.set(pinId, { x: 0, y: startYIn + gapY * index });
+	}
+
+	const startYOut =
+		size.y / 2 - (gapY * (source.outputNodePinIds.length - 1)) / 2;
+	for (const [index, pinId] of source.outputNodePinIds.entries()) {
+		nodePinOffsetById.set(pinId, { x: size.x, y: startYOut + gapY * index });
+	}
+
+	return { size, nodePinOffsetById };
+}

--- a/src/pages/edit/Editor/renderer/Node/components/Default/index.tsx
+++ b/src/pages/edit/Editor/renderer/Node/components/Default/index.tsx
@@ -8,18 +8,18 @@ export function CCComponentEditorRendererNodeDefaultRenderer(
 		<>
 			<text
 				fill={theme.palette.textPrimary}
-				x={props.geometry.rect.position.x}
-				y={props.geometry.rect.position.y - 5}
+				x={0}
+				y={-5}
 				textAnchor="start"
 				fontSize={12}
 			>
 				{props.component.name}
 			</text>
 			<rect
-				x={props.geometry.rect.position.x}
-				y={props.geometry.rect.position.y}
-				width={props.geometry.rect.size.x}
-				height={props.geometry.rect.size.y}
+				x={0}
+				y={0}
+				width="100%"
+				height="100%"
 				fill={theme.palette.white}
 				stroke={
 					props.nodeState.isSelected

--- a/src/pages/edit/Editor/renderer/Node/components/Display/ConfigSettingButton.tsx
+++ b/src/pages/edit/Editor/renderer/Node/components/Display/ConfigSettingButton.tsx
@@ -1,26 +1,117 @@
 import { SettingsOutlined } from "@mui/icons-material";
-import { IconButton } from "@mui/material";
-import type { CCNodeId } from "../../../../../../../store/node";
-import type { CCComponentEditorRendererNodeGeometry } from "../../types";
+import {
+	Button,
+	FormLabel,
+	IconButton,
+	Popover,
+	Stack,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { useState } from "react";
+import type { CCIntrinsicComponentDisplaySpec } from "../../../../../../../store/intrinsics/types";
 
 type Props = {
-	nodeId: CCNodeId;
-	geometry: CCComponentEditorRendererNodeGeometry;
+	config: CCIntrinsicComponentDisplaySpec["config"];
+	onConfigChange: (config: CCIntrinsicComponentDisplaySpec["config"]) => void;
 };
 
 export function CCComponentEditorRendererNodeDisplayRendererConfigSettingButton(
-	_props: Props,
+	props: Props,
 ) {
+	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+	const [newConfig, setNewConfig] = useState(props.config);
+
 	return (
-		<IconButton
-			sx={{ width: "20px", height: "20px" }}
-			onPointerDown={(e) => {
-				e.stopPropagation();
-			}}
-			disableTouchRipple
-			disableFocusRipple
-		>
-			<SettingsOutlined sx={{ width: "12px", height: "12px" }} />
-		</IconButton>
+		<>
+			<IconButton
+				sx={{ width: "20px", height: "20px" }}
+				// Prevent the drag behavior of the parent node when clicking the button
+				onPointerDown={(e) => e.stopPropagation()}
+				onClick={(e) => {
+					e.stopPropagation();
+					setAnchorEl(e.currentTarget);
+					setNewConfig(props.config);
+				}}
+			>
+				<SettingsOutlined sx={{ width: "12px", height: "12px" }} />
+			</IconButton>
+			<Popover
+				anchorEl={anchorEl}
+				open={Boolean(anchorEl)}
+				onClose={() => setAnchorEl(null)}
+				slotProps={{
+					root: { onPointerDown: (e) => e.stopPropagation() },
+					paper: { sx: { width: "300px", p: 2 } },
+				}}
+			>
+				<form
+					onSubmit={(e) => {
+						e.preventDefault();
+						props.onConfigChange(newConfig);
+						setAnchorEl(null);
+					}}
+				>
+					<Typography variant="h6" gutterBottom>
+						Display Settings
+					</Typography>
+					<FormLabel component="div" sx={{ mb: 0.5 }}>
+						Resolution
+					</FormLabel>
+					<Stack direction="row" alignItems="center" gap={1}>
+						<TextField
+							value={newConfig.resolution.x || ""}
+							onChange={(e) =>
+								setNewConfig((prev) => ({
+									...prev,
+									resolution: {
+										...prev.resolution,
+										x: parseInt(e.target.value, 10) || 0,
+									},
+								}))
+							}
+							size="small"
+							sx={{ flex: 1 }}
+							slotProps={{
+								htmlInput: { inputMode: "numeric", sx: { textAlign: "end" } },
+							}}
+						/>
+						<Typography component="span" variant="body1">
+							x
+						</Typography>
+						<TextField
+							value={newConfig.resolution.y || ""}
+							onChange={(e) =>
+								setNewConfig((prev) => ({
+									...prev,
+									resolution: {
+										...prev.resolution,
+										y: parseInt(e.target.value, 10) || 0,
+									},
+								}))
+							}
+							size="small"
+							sx={{ flex: 1 }}
+							slotProps={{
+								htmlInput: { inputMode: "numeric", sx: { textAlign: "end" } },
+							}}
+						/>
+					</Stack>
+					<Stack direction="row" justifyContent="flex-end" mt={2} gap={1}>
+						<Button
+							type="button"
+							variant="outlined"
+							size="small"
+							onClick={() => setAnchorEl(null)}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" variant="contained" size="small">
+							Apply
+						</Button>
+					</Stack>
+				</form>
+			</Popover>
+		</>
 	);
 }

--- a/src/pages/edit/Editor/renderer/Node/components/Display/ConfigSettingButton.tsx
+++ b/src/pages/edit/Editor/renderer/Node/components/Display/ConfigSettingButton.tsx
@@ -1,0 +1,26 @@
+import { SettingsOutlined } from "@mui/icons-material";
+import { IconButton } from "@mui/material";
+import type { CCNodeId } from "../../../../../../../store/node";
+import type { CCComponentEditorRendererNodeGeometry } from "../../types";
+
+type Props = {
+	nodeId: CCNodeId;
+	geometry: CCComponentEditorRendererNodeGeometry;
+};
+
+export function CCComponentEditorRendererNodeDisplayRendererConfigSettingButton(
+	_props: Props,
+) {
+	return (
+		<IconButton
+			sx={{ width: "20px", height: "20px" }}
+			onPointerDown={(e) => {
+				e.stopPropagation();
+			}}
+			disableTouchRipple
+			disableFocusRipple
+		>
+			<SettingsOutlined sx={{ width: "12px", height: "12px" }} />
+		</IconButton>
+	);
+}

--- a/src/pages/edit/Editor/renderer/Node/components/Display/geometry.ts
+++ b/src/pages/edit/Editor/renderer/Node/components/Display/geometry.ts
@@ -1,33 +1,34 @@
+import nullthrows from "nullthrows";
 import { type Vector2, vector2 } from "../../../../../../../common/vector2";
+import type { CCIntrinsicComponentDisplaySpec } from "../../../../../../../store/intrinsics/types";
 import type { CCNodePinId } from "../../../../../../../store/nodePin";
 import type {
-	CCComponentEditorRendererNodeGeometryCalculator,
-	CCComponentEditorRendererNodeGeometrySource,
+	CCComponentEditorRendererNodeLayout,
+	CCComponentEditorRendererNodeLayoutSource,
 } from "../../types";
 
-const width = 320;
-const height = 200;
+const size = { x: 320, y: 200 };
 
-export const ccComponentRendererNodeDisplayGeometryCalculator: CCComponentEditorRendererNodeGeometryCalculator =
-	(source: CCComponentEditorRendererNodeGeometrySource) => {
-		const size: Vector2 = {
-			x: width,
-			y: height,
-		};
+export const ccComponentEditorRendererNodeDisplayLayoutConstants = {
+	padding: 8,
+	gridSize: 12,
+	gridSizeDisplayWidth: 60,
+};
 
-		return {
-			rect: {
-				position: vector2.sub(source.position, vector2.div(size, 2)),
-				size,
-			},
-			nodePinPositionById: new Map<CCNodePinId, Vector2>(
-				source.inputNodePinIds.map(
-					(id) =>
-						[
-							id,
-							vector2.create(source.position.x - size.x / 2, source.position.y),
-						] as const,
-				),
-			),
-		};
+export function ccComponentRendererNodeDisplayLayoutCalculator(
+	source: CCComponentEditorRendererNodeLayoutSource,
+): CCComponentEditorRendererNodeLayout {
+	const { padding, gridSize, gridSizeDisplayWidth } =
+		ccComponentEditorRendererNodeDisplayLayoutConstants;
+	const config = source.config as CCIntrinsicComponentDisplaySpec["config"];
+
+	return {
+		size: {
+			x: gridSizeDisplayWidth + gridSize * config.resolution.x + padding * 2,
+			y: gridSize * config.resolution.y + padding * 2,
+		},
+		nodePinOffsetById: new Map<CCNodePinId, Vector2>([
+			[nullthrows(source.inputNodePinIds[0]), vector2.create(0, size.y / 2)],
+		]),
 	};
+}

--- a/src/pages/edit/Editor/renderer/Node/components/Display/geometry.ts
+++ b/src/pages/edit/Editor/renderer/Node/components/Display/geometry.ts
@@ -7,8 +7,6 @@ import type {
 	CCComponentEditorRendererNodeLayoutSource,
 } from "../../types";
 
-const size = { x: 320, y: 200 };
-
 export const ccComponentEditorRendererNodeDisplayLayoutConstants = {
 	padding: 8,
 	gridSize: 12,
@@ -22,11 +20,13 @@ export function ccComponentRendererNodeDisplayLayoutCalculator(
 		ccComponentEditorRendererNodeDisplayLayoutConstants;
 	const config = source.config as CCIntrinsicComponentDisplaySpec["config"];
 
+	const size = {
+		x: gridSizeDisplayWidth + gridSize * config.resolution.x + padding * 2,
+		y: gridSize * config.resolution.y + padding * 2,
+	};
+
 	return {
-		size: {
-			x: gridSizeDisplayWidth + gridSize * config.resolution.x + padding * 2,
-			y: gridSize * config.resolution.y + padding * 2,
-		},
+		size,
 		nodePinOffsetById: new Map<CCNodePinId, Vector2>([
 			[nullthrows(source.inputNodePinIds[0]), vector2.create(0, size.y / 2)],
 		]),

--- a/src/pages/edit/Editor/renderer/Node/components/Display/index.tsx
+++ b/src/pages/edit/Editor/renderer/Node/components/Display/index.tsx
@@ -5,6 +5,9 @@ import type { CCIntrinsicComponentDisplaySpec } from "../../../../../../../store
 import { useStore } from "../../../../../../../store/react";
 import { useComponentEditorStore } from "../../../../store";
 import type { CCComponentEditorRendererNodeRendererProps } from "../../types";
+import { CCComponentEditorRendererNodeDefaultRenderer } from "../Default";
+import { CCComponentEditorRendererNodeDisplayRendererConfigSettingButton } from "./ConfigSettingButton";
+import { ccComponentEditorRendererNodeDisplayLayoutConstants } from "./geometry";
 
 export function CCComponentEditorRendererNodeDisplayRenderer(
 	props: CCComponentEditorRendererNodeRendererProps,
@@ -23,38 +26,27 @@ export function CCComponentEditorRendererNodeDisplayRenderer(
 			? editorState.getNodePinValue(inputNodePin.id)
 			: undefined;
 
+	const { padding, gridSize, gridSizeDisplayWidth } =
+		ccComponentEditorRendererNodeDisplayLayoutConstants;
+
 	return (
 		<>
-			<rect
-				x={props.geometry.rect.position.x}
-				y={props.geometry.rect.position.y}
-				width={props.geometry.rect.size.x}
-				height={props.geometry.rect.size.y}
-				fill={theme.palette.white}
-				stroke={
-					props.nodeState.isSelected
-						? theme.palette.primary
-						: theme.palette.textPrimary
-				}
-				strokeWidth={2}
-				rx={2}
-			/>
+			<CCComponentEditorRendererNodeDefaultRenderer {...props} />
 			<text
-				x={props.geometry.rect.position.x + 8}
-				y={props.geometry.rect.position.y + 20}
-				fontSize={12}
-				fill={theme.palette.textPrimary}
-			>
-				Display
-			</text>
-			<text
-				x={props.geometry.rect.position.x + 8}
-				y={props.geometry.rect.position.y + 40}
+				x={padding}
+				y={padding}
 				fontSize={16}
 				fill={theme.palette.textPrimary}
+				dominantBaseline="hanging"
 			>
 				{config.resolution.x}x{config.resolution.y}
 			</text>
+			<foreignObject x={padding / 2} y={padding + 16} width={32} height={32}>
+				<CCComponentEditorRendererNodeDisplayRendererConfigSettingButton
+					nodeId={props.node.id}
+					geometry={props.geometry}
+				/>
+			</foreignObject>
 			{Array(config.resolution.y)
 				.keys()
 				.map((y) =>
@@ -63,10 +55,10 @@ export function CCComponentEditorRendererNodeDisplayRenderer(
 						.map((x) => (
 							<rect
 								key={`${x}-${y}`}
-								x={props.geometry.rect.position.x + 64 + x * 12}
-								y={props.geometry.rect.position.y + 8 + y * 12}
-								width={12}
-								height={12}
+								x={padding + gridSizeDisplayWidth + x * gridSize}
+								y={padding + y * gridSize}
+								width={gridSize}
+								height={gridSize}
 								fill={
 									inputValue?.[
 										config.resolution.x * config.resolution.y -

--- a/src/pages/edit/Editor/renderer/Node/components/Display/index.tsx
+++ b/src/pages/edit/Editor/renderer/Node/components/Display/index.tsx
@@ -13,7 +13,11 @@ export function CCComponentEditorRendererNodeDisplayRenderer(
 	props: CCComponentEditorRendererNodeRendererProps,
 ) {
 	const { store } = useStore();
+
 	const config = props.node.config as CCIntrinsicComponentDisplaySpec["config"];
+	const updateConfig = (newConfig: CCIntrinsicComponentDisplaySpec["config"]) =>
+		store.nodes.update(props.node.id, { config: newConfig });
+
 	const inputNodePin = nullthrows(
 		store.nodePins
 			.getManyByNodeId(props.node.id)
@@ -43,8 +47,8 @@ export function CCComponentEditorRendererNodeDisplayRenderer(
 			</text>
 			<foreignObject x={padding / 2} y={padding + 16} width={32} height={32}>
 				<CCComponentEditorRendererNodeDisplayRendererConfigSettingButton
-					nodeId={props.node.id}
-					geometry={props.geometry}
+					config={config}
+					onConfigChange={updateConfig}
 				/>
 			</foreignObject>
 			{Array(config.resolution.y)

--- a/src/pages/edit/Editor/renderer/Node/components/Display/index.tsx
+++ b/src/pages/edit/Editor/renderer/Node/components/Display/index.tsx
@@ -64,10 +64,7 @@ export function CCComponentEditorRendererNodeDisplayRenderer(
 								width={gridSize}
 								height={gridSize}
 								fill={
-									inputValue?.[
-										config.resolution.x * config.resolution.y -
-											(1 + x + config.resolution.x * y)
-									]
+									inputValue?.[x + config.resolution.x * y]
 										? theme.palette.black
 										: theme.palette.white
 								}

--- a/src/pages/edit/Editor/renderer/Node/geometry.ts
+++ b/src/pages/edit/Editor/renderer/Node/geometry.ts
@@ -1,37 +1,43 @@
 import nullthrows from "nullthrows";
+import { type Vector2, vector2 } from "../../../../../common/vector2";
 import type CCStore from "../../../../../store";
 import {
 	type CCIntrinsicComponentType,
 	ccIntrinsicComponentTypes,
 } from "../../../../../store/intrinsics/types";
 import type { CCNodeId } from "../../../../../store/node";
-import { ccComponentRendererNodeDefaultGeometryCalculator } from "./components/Default/geometry";
-import { ccComponentRendererNodeDisplayGeometryCalculator } from "./components/Display/geometry";
+import { ccComponentRendererNodeDefaultLayoutCalculator } from "./components/Default/geometry";
+import { ccComponentRendererNodeDisplayLayoutCalculator } from "./components/Display/geometry";
 import type {
-	CCComponentEditorRendererNodeGeometryCalculator,
-	CCComponentEditorRendererNodeGeometrySource,
+	CCComponentEditorRendererNodeGeometry,
+	CCComponentEditorRendererNodeLayout,
+	CCComponentEditorRendererNodeLayoutSource,
 } from "./types";
 
-const specialGeometryCalculators: Partial<
-	Record<
-		CCIntrinsicComponentType,
-		CCComponentEditorRendererNodeGeometryCalculator
-	>
-> = {
+const specialLayoutCalculators: {
+	[key in CCIntrinsicComponentType]?: (
+		source: CCComponentEditorRendererNodeLayoutSource,
+	) => CCComponentEditorRendererNodeLayout;
+} = {
 	[ccIntrinsicComponentTypes.DISPLAY]:
-		ccComponentRendererNodeDisplayGeometryCalculator,
+		ccComponentRendererNodeDisplayLayoutCalculator,
 };
 
-export default function getCCComponentEditorRendererNodeGeometry(
+export function getCCComponentEditorRendererNodeLayout(
 	store: CCStore,
 	nodeId: CCNodeId,
-) {
+): CCComponentEditorRendererNodeLayout {
 	const node = nullthrows(store.nodes.get(nodeId));
 	const component = nullthrows(store.components.get(node.componentId));
 	const nodePins = store.nodePins.getManyByNodeId(nodeId);
 
-	const source: CCComponentEditorRendererNodeGeometrySource = {
-		position: node.position,
+	const layoutCalculator =
+		(component.intrinsicType &&
+			specialLayoutCalculators[component.intrinsicType]) ??
+		ccComponentRendererNodeDefaultLayoutCalculator;
+
+	return layoutCalculator({
+		config: node.config,
 		inputNodePinIds: nodePins
 			.filter((np) => {
 				const cp = nullthrows(store.componentPins.get(np.componentPinId));
@@ -44,11 +50,32 @@ export default function getCCComponentEditorRendererNodeGeometry(
 				return cp.type === "output";
 			})
 			.map((np) => np.id),
-	};
+	});
+}
 
-	const calculator =
-		(component.intrinsicType &&
-			specialGeometryCalculators[component.intrinsicType]) ??
-		ccComponentRendererNodeDefaultGeometryCalculator;
-	return calculator(source);
+export function ccComponentEditorRendererLayoutToGeometry(
+	layout: CCComponentEditorRendererNodeLayout,
+	nodePosition: Vector2,
+): CCComponentEditorRendererNodeGeometry {
+	const position = vector2.sub(nodePosition, vector2.div(layout.size, 2));
+	return {
+		rect: { position: position, size: layout.size },
+		nodePinPositionById: new Map(
+			layout.nodePinOffsetById
+				.entries()
+				.map(([nodePinId, offset]) => [
+					nodePinId,
+					vector2.add(position, offset),
+				]),
+		),
+	};
+}
+
+export function getCCComponentEditorRendererNodeGeometry(
+	store: CCStore,
+	nodeId: CCNodeId,
+): CCComponentEditorRendererNodeGeometry {
+	const node = nullthrows(store.nodes.get(nodeId));
+	const layout = getCCComponentEditorRendererNodeLayout(store, nodeId);
+	return ccComponentEditorRendererLayoutToGeometry(layout, node.position);
 }

--- a/src/pages/edit/Editor/renderer/Node/geometry.ts
+++ b/src/pages/edit/Editor/renderer/Node/geometry.ts
@@ -6,6 +6,7 @@ import {
 	ccIntrinsicComponentTypes,
 } from "../../../../../store/intrinsics/types";
 import type { CCNodeId } from "../../../../../store/node";
+import { ccComponentRendererNodeConstLayoutCalculator } from "./components/Const/geometry";
 import { ccComponentRendererNodeDefaultLayoutCalculator } from "./components/Default/geometry";
 import { ccComponentRendererNodeDisplayLayoutCalculator } from "./components/Display/geometry";
 import type {
@@ -21,6 +22,8 @@ const specialLayoutCalculators: {
 } = {
 	[ccIntrinsicComponentTypes.DISPLAY]:
 		ccComponentRendererNodeDisplayLayoutCalculator,
+	[ccIntrinsicComponentTypes.CONST]:
+		ccComponentRendererNodeConstLayoutCalculator,
 };
 
 export function getCCComponentEditorRendererNodeLayout(

--- a/src/pages/edit/Editor/renderer/Node/index.tsx
+++ b/src/pages/edit/Editor/renderer/Node/index.tsx
@@ -12,7 +12,10 @@ import { useComponentEditorStore } from "../../store";
 import CCComponentEditorRendererNodePin from "../NodePin";
 import { CCComponentEditorRendererNodeDefaultRenderer } from "./components/Default";
 import { CCComponentEditorRendererNodeDisplayRenderer } from "./components/Display";
-import getCCComponentEditorRendererNodeGeometry from "./geometry";
+import {
+	ccComponentEditorRendererLayoutToGeometry,
+	getCCComponentEditorRendererNodeLayout,
+} from "./geometry";
 import type {
 	CCComponentEditorRendererNodeRendererNodeState,
 	CCComponentEditorRendererNodeRendererProps,
@@ -44,7 +47,11 @@ const CCComponentEditorRendererNode = ensureStoreItem(
 			vector2.zero,
 		);
 
-		const geometry = getCCComponentEditorRendererNodeGeometry(store, nodeId);
+		const layout = getCCComponentEditorRendererNodeLayout(store, nodeId);
+		const geometry = ccComponentEditorRendererLayoutToGeometry(
+			layout,
+			node.position,
+		);
 		const Renderer =
 			(component.intrinsicType && specialRenderers[component.intrinsicType]) ||
 			CCComponentEditorRendererNodeDefaultRenderer;
@@ -86,8 +93,13 @@ const CCComponentEditorRendererNode = ensureStoreItem(
 
 		return (
 			<>
-				{/** biome-ignore lint/a11y/noStaticElementInteractions: SVG */}
-				<g
+				{/** biome-ignore lint/a11y/noSvgWithoutTitle: SVG */}
+				<svg
+					x={geometry.rect.position.x}
+					y={geometry.rect.position.y}
+					width={geometry.rect.size.x}
+					height={geometry.rect.size.y}
+					overflow="visible"
 					onPointerDown={handlePointerDown}
 					onPointerMove={handlePointerMove}
 					onPointerUp={handlePointerUp}
@@ -104,9 +116,10 @@ const CCComponentEditorRendererNode = ensureStoreItem(
 						node={node}
 						nodeState={nodeState}
 						component={component}
+						layout={layout}
 						geometry={geometry}
 					/>
-				</g>
+				</svg>
 				{store.nodePins.getManyByNodeId(nodeId).map((nodePin) => (
 					<CCComponentEditorRendererNodePin
 						key={nodePin.id}

--- a/src/pages/edit/Editor/renderer/Node/index.tsx
+++ b/src/pages/edit/Editor/renderer/Node/index.tsx
@@ -10,6 +10,7 @@ import ensureStoreItem from "../../../../../store/react/error";
 import { useComponent, useNode } from "../../../../../store/react/selectors";
 import { useComponentEditorStore } from "../../store";
 import CCComponentEditorRendererNodePin from "../NodePin";
+import { CCComponentEditorRendererNodeConstRenderer } from "./components/Const";
 import { CCComponentEditorRendererNodeDefaultRenderer } from "./components/Default";
 import { CCComponentEditorRendererNodeDisplayRenderer } from "./components/Display";
 import {
@@ -29,6 +30,7 @@ const specialRenderers: Partial<
 > = {
 	[ccIntrinsicComponentTypes.DISPLAY]:
 		CCComponentEditorRendererNodeDisplayRenderer,
+	[ccIntrinsicComponentTypes.CONST]: CCComponentEditorRendererNodeConstRenderer,
 };
 
 export type CCComponentEditorRendererNodeProps = {

--- a/src/pages/edit/Editor/renderer/Node/types.ts
+++ b/src/pages/edit/Editor/renderer/Node/types.ts
@@ -8,15 +8,17 @@ export type CCComponentEditorRendererNodeRendererProps = {
 	node: CCNode;
 	nodeState: CCComponentEditorRendererNodeRendererNodeState;
 	component: CCComponent;
+	layout: CCComponentEditorRendererNodeLayout;
 	geometry: CCComponentEditorRendererNodeGeometry;
 };
 
-export type CCComponentEditorRendererNodeRendererNodeState = {
-	isSelected: boolean;
+export type CCComponentEditorRendererNodeLayout = {
+	size: Vector2;
+	nodePinOffsetById: Map<CCNodePinId, Vector2>;
 };
 
-export type CCComponentEditorRendererNodeGeometrySource = {
-	position: Vector2;
+export type CCComponentEditorRendererNodeLayoutSource = {
+	config: CCNode["config"];
 	inputNodePinIds: CCNodePinId[];
 	outputNodePinIds: CCNodePinId[];
 };
@@ -26,6 +28,6 @@ export type CCComponentEditorRendererNodeGeometry = {
 	nodePinPositionById: Map<CCNodePinId, Vector2>;
 };
 
-export type CCComponentEditorRendererNodeGeometryCalculator = (
-	source: CCComponentEditorRendererNodeGeometrySource,
-) => CCComponentEditorRendererNodeGeometry;
+export type CCComponentEditorRendererNodeRendererNodeState = {
+	isSelected: boolean;
+};

--- a/src/pages/edit/Editor/renderer/NodePin/index.tsx
+++ b/src/pages/edit/Editor/renderer/NodePin/index.tsx
@@ -14,7 +14,7 @@ import {
 	CCComponentEditorRendererConnectionCore,
 	type CCComponentEditorRendererConnectionEndpoint,
 } from "./../Connection";
-import getCCComponentEditorRendererNodeGeometry from "./../Node/geometry";
+import { getCCComponentEditorRendererNodeGeometry } from "./../Node/geometry";
 
 const NODE_PIN_POSITION_SENSITIVITY = 10;
 

--- a/src/pages/edit/Editor/store/slices/core/index.ts
+++ b/src/pages/edit/Editor/store/slices/core/index.ts
@@ -87,7 +87,7 @@ export const createComponentEditorStoreCoreSlice: ComponentEditorSliceCreator<
 						return {
 							...state,
 							inputValues: new Map(state.inputValues).set(
-								JSON.stringify(inputValueKey),
+								serializeInputValueKey(inputValueKey),
 								value,
 							),
 						};

--- a/src/pages/edit/Editor/store/slices/core/index.ts
+++ b/src/pages/edit/Editor/store/slices/core/index.ts
@@ -191,11 +191,6 @@ export const createComponentEditorStoreCoreSlice: ComponentEditorSliceCreator<
 				}
 				if (isUpdated) editorStore.setState((s) => ({ ...s }));
 			};
-			store.nodes.on("didRegister", executeSimulation);
-			store.nodes.on("didUpdate", executeSimulation);
-			store.nodes.on("didUnregister", executeSimulation);
-			store.connections.on("didRegister", executeSimulation);
-			store.connections.on("didUnregister", executeSimulation);
 			editorStore.subscribe(executeSimulation);
 		},
 	};

--- a/src/pages/edit/Editor/store/slices/core/index.ts
+++ b/src/pages/edit/Editor/store/slices/core/index.ts
@@ -11,7 +11,11 @@ import type {
 // import type { CCComponentId } from "../../../../../../store/component";
 import simulateComponent from "../../../../../../store/simulation";
 import type { ComponentEditorSliceCreator } from "../../types";
-import type { EditorStoreCoreSlice, InputValueKey } from "./types";
+import {
+	type EditorStoreCoreSlice,
+	type InputValueKey,
+	serializeInputValueKey,
+} from "./types";
 
 export function stringifySimulationValue(value: SimulationValue): string {
 	const binary = value.map((v) => (v ? "1" : "0")).join("");
@@ -44,30 +48,39 @@ export const createComponentEditorStoreCoreSlice: ComponentEditorSliceCreator<
 				/** @private */
 				inputValues: new Map(),
 				getInputValue(inputValueKey: InputValueKey) {
-					const value = get().inputValues.get(JSON.stringify(inputValueKey));
-					if (!value) {
-						const previousTimeStepValue = get().inputValues.get(
-							JSON.stringify([inputValueKey[0], inputValueKey[1] - 1]),
-						);
-						if (previousTimeStepValue) {
-							get().setInputValue(inputValueKey, previousTimeStepValue);
-							return previousTimeStepValue;
-						}
-						const bitWidthStatus =
-							store.componentPins.getComponentPinBitWidthStatus(
-								inputValueKey[0],
-							);
-						if (bitWidthStatus.isFixed) {
-							const newValue = new Array(bitWidthStatus.bitWidth).fill(false);
-							return newValue;
-						}
-						if (bitWidthStatus.fixMode === "manual") {
-							throw new Error("Cannot determine bit width");
-						}
-						const newValue = [false];
-						return newValue;
+					// If value exists for the current time step, return it
+					const value = get().inputValues.get(
+						serializeInputValueKey(inputValueKey),
+					);
+					if (value) return value;
+
+					// If not, try to find the value from the previous time step
+					const previousTimeStepValue = get().inputValues.get(
+						serializeInputValueKey({
+							...inputValueKey,
+							timeStep: inputValueKey.timeStep - 1,
+						}),
+					);
+					if (previousTimeStepValue) {
+						get().setInputValue(inputValueKey, previousTimeStepValue);
+						return previousTimeStepValue;
 					}
-					return value;
+
+					// If not found, initialize the value based on the bit width of the pin
+					const componentPin = nullthrows(
+						store.componentPins.get(inputValueKey.componentPinId),
+					);
+					const bitWidthStatus = store.nodePins.getNodePinBitWidthStatus(
+						nullthrows(
+							componentPin.implementation,
+							"Cannot get input value for intrinsic component pin",
+						),
+					);
+					return bitWidthStatus.isFixed
+						? // If the bit width is fixed, initialize the value with the specified bit width
+							new Array(bitWidthStatus.bitWidth).fill(false)
+						: // If the bit width is not fixed, initialize the single-bit value as false
+							[false];
 				},
 				setInputValue(inputValueKey: InputValueKey, value: SimulationValue) {
 					set((state) => {
@@ -178,7 +191,7 @@ export const createComponentEditorStoreCoreSlice: ComponentEditorSliceCreator<
 						if (pin.type === "input") {
 							inputValues.set(
 								pin.id,
-								editorState.getInputValue([pin.id, timeStep]),
+								editorState.getInputValue({ componentPinId: pin.id, timeStep }),
 							);
 						}
 					}

--- a/src/pages/edit/Editor/store/slices/core/types.ts
+++ b/src/pages/edit/Editor/store/slices/core/types.ts
@@ -13,7 +13,13 @@ export type RangeSelect = { start: Vector2; end: Vector2 } | null;
 
 export type TimeStep = number;
 
-export type InputValueKey = [CCComponentPinId, TimeStep];
+export type InputValueKey = {
+	componentPinId: CCComponentPinId;
+	timeStep: TimeStep;
+};
+export function serializeInputValueKey(key: InputValueKey): string {
+	return `${key.componentPinId}:${key.timeStep}`;
+}
 
 export type NodePinPropertyEditorTarget = {
 	nodeId: CCNodeId;

--- a/src/store/component.ts
+++ b/src/store/component.ts
@@ -219,3 +219,28 @@ export function validateAllComponents(store: CCStore) {
 		validateComponent(store, component.id);
 	}
 }
+
+export function isEachInputPinConnected(
+	store: CCStore,
+	componentId: CCComponentId,
+) {
+	const component = nullthrows(store.components.get(componentId));
+	if (component.intrinsicType) return true;
+	const nodes = store.nodes.getManyByParentComponentId(componentId);
+	for (const node of nodes) {
+		const nodePins = store.nodePins.getManyByNodeId(node.id);
+		for (const nodePin of nodePins) {
+			const componentPin = nullthrows(
+				store.componentPins.get(nodePin.componentPinId),
+			);
+			if (componentPin.type === "input") {
+				const connectionsAssociatedWithNodePin =
+					store.connections.getConnectionsByNodePinId(nodePin.id);
+				if (connectionsAssociatedWithNodePin.length === 0) {
+					return false;
+				}
+			}
+		}
+	}
+	return true;
+}

--- a/src/store/componentPin.ts
+++ b/src/store/componentPin.ts
@@ -208,6 +208,7 @@ export class CCComponentPinStore extends EventEmitter<CCComponentPinStoreEvents>
 	 * Get the bit width status of a component pin
 	 * @param pinId id of pin
 	 * @returns bit width status of the pin
+	 * @deprecated use getNodePinBitWidthStatus instead
 	 */
 	getComponentPinBitWidthStatus(
 		pinId: CCComponentPinId,

--- a/src/store/componentPin.ts
+++ b/src/store/componentPin.ts
@@ -5,7 +5,7 @@ import type { Opaque } from "type-fest";
 import type CCStore from ".";
 import type { CCComponentId } from "./component";
 import { IntrinsicComponentDefinition } from "./intrinsics/base";
-import { aggregate, decompose, input, output } from "./intrinsics/definitions";
+import { input, output } from "./intrinsics/definitions";
 import type { CCNodePinId } from "./nodePin";
 
 export type CCComponentPin = {
@@ -36,11 +36,13 @@ export type CCNodePinBitWidthStatus =
 /**
  * The bit width status of a component pin definition.
  * - `isFixed: false, fixMode: "automatic"` — the bit width is not yet determined and will be inferred automatically from connections.
- * - `isFixed: false, fixMode: "manual"` — the bit width is not yet determined and must be specified manually by the user.
- * - `isFixed: true` — the bit width is known and available as `bitWidth`.
+ * - `isFixed: false, fixMode: "nodeDependent"` — the bit width differs per node instance
+ *   (it comes from the config of the node and/or the bit widths manually specified for its
+ *   pins), so it can only be resolved by {@link CCNodePinStore.getNodePinBitWidthStatus}.
+ * - `isFixed: true` — the bit width is determined by the component definition itself and available as `bitWidth`.
  */
 export type CCComponentPinBitWidthStatus =
-	| { isFixed: false; fixMode: "automatic" | "manual" }
+	| { isFixed: false; fixMode: "automatic" | "nodeDependent" }
 	| { isFixed: true; bitWidth: number };
 
 export type CCComponentPinStoreEvents = {
@@ -205,10 +207,11 @@ export class CCComponentPinStore extends EventEmitter<CCComponentPinStoreEvents>
 	}
 
 	/**
-	 * Get the bit width status of a component pin
+	 * Get how the bit width of a component pin is determined. It is resolved only as far
+	 * as the component definition allows; use {@link CCNodePinStore.getNodePinBitWidthStatus}
+	 * to get the width of a concrete node pin.
 	 * @param pinId id of pin
 	 * @returns bit width status of the pin
-	 * @deprecated use getNodePinBitWidthStatus instead
 	 */
 	getComponentPinBitWidthStatus(
 		pinId: CCComponentPinId,
@@ -220,33 +223,19 @@ export class CCComponentPinStore extends EventEmitter<CCComponentPinStoreEvents>
 		const intrinsicPinAttributes =
 			IntrinsicComponentDefinition.getPinAttributesByPinId(pin.id);
 		if (intrinsicPinAttributes) {
-			// TODO: This is a temporary workaround to allow the bit width of aggregate and decompose pins to be calculated outside of the normal inference process.
-			// We should eventually refactor the bit width inference process to handle these cases more elegantly.
-			if (pin.id === aggregate.outputPin.Out.id)
-				return { isFixed: false, fixMode: "manual" };
-			if (pin.id === decompose.inputPin.In.id)
-				return { isFixed: false, fixMode: "manual" };
-
-			if (intrinsicPinAttributes.bitWidthPolicy.type === "inferred")
-				return { isFixed: false, fixMode: "automatic" };
-			if (intrinsicPinAttributes.bitWidthPolicy.type === "configurable")
-				return { isFixed: false, fixMode: "manual" };
-			if (intrinsicPinAttributes.bitWidthPolicy.type === "fixed") {
-				const definition = nullthrows(
-					IntrinsicComponentDefinition.getByComponentId(pin.componentId),
-					`Intrinsic component definition not found for component ID: ${pin.componentId}`,
-				);
-				return {
-					isFixed: true,
-					bitWidth: intrinsicPinAttributes.bitWidthPolicy.calculateBitWidth(
-						definition.initialConfig,
-						{},
-					),
-				};
+			switch (intrinsicPinAttributes.bitWidthPolicy.type) {
+				case "inferred":
+					return { isFixed: false, fixMode: "automatic" };
+				// Both policies need the node the pin belongs to (its config and the bit widths
+				// manually specified for its pins), which is unknown at the component pin level.
+				case "configurable":
+				case "calculated":
+					return { isFixed: false, fixMode: "nodeDependent" };
+				default:
+					throw new Error(
+						`Unknown bit width policy: ${intrinsicPinAttributes.bitWidthPolicy satisfies never}`,
+					);
 			}
-			throw new Error(
-				`Unknown bit width policy: ${intrinsicPinAttributes.bitWidthPolicy satisfies never}`,
-			);
 		}
 
 		// User-defined components

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -61,6 +61,26 @@ export class CCConnectionStore extends EventEmitter<CCConnectionStoreEvents> {
 				this.unregister(connections.map((connection) => connection.id));
 			}
 		});
+		// A config change can change the bit width of a pin (e.g. the resolution of a
+		// display), which invalidates the connections that were valid when they were made.
+		// CCStore mounts CCNodePinStore first, so its bit width cache is already dropped.
+		this.#store.nodes.on("didUpdateConfig", (node) => {
+			// TODO: Dropping a connection can in turn invalidate another one. Resolving that
+			// needs a repeated sweep, which the re-validation on `didRegister` below lacks too.
+			const invalidatedConnections = this.getMany().filter(
+				(connection) =>
+					connection.parentComponentId === node.parentComponentId &&
+					!this.#store.nodePins.hasCompatibleBitWidths(
+						connection.from,
+						connection.to,
+					),
+			);
+			if (invalidatedConnections.length > 0) {
+				this.unregister(
+					invalidatedConnections.map((connection) => connection.id),
+				);
+			}
+		});
 		this.#store.connections.on("didRegister", (connection) => {
 			const component = nullthrows(
 				this.#store.components.get(connection.parentComponentId),

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -61,6 +61,35 @@ export class CCConnectionStore extends EventEmitter<CCConnectionStoreEvents> {
 				this.unregister(connections.map((connection) => connection.id));
 			}
 		});
+		this.#store.connections.on("didRegister", (connection) => {
+			const component = nullthrows(
+				this.#store.components.get(connection.parentComponentId),
+			);
+			const nodes = this.#store.nodes.getManyByComponentId(component.id);
+			for (const node of nodes) {
+				const nodePins = this.#store.nodePins.getManyByNodeId(node.id);
+				for (const nodePin of nodePins) {
+					const connections = this.getConnectionsByNodePinId(nodePin.id);
+					for (const connection of connections) {
+						const parentComponentId = connection.parentComponentId;
+						const from = connection.from;
+						const to = connection.to;
+						this.unregister([connection.id]).then(() => {
+							if (this.#store.nodePins.isConnectable(from, to)) {
+								this.register(
+									CCConnectionStore.create({
+										from,
+										to,
+										parentComponentId,
+										bentPortion: 0.5,
+									}),
+								);
+							}
+						});
+					}
+				}
+			}
+		});
 	}
 
 	/**

--- a/src/store/intrinsics/base.ts
+++ b/src/store/intrinsics/base.ts
@@ -48,17 +48,23 @@ type IntrinsicComponentPinAttributes<Spec extends CCIntrinsicComponentSpec> = {
 	isBitWidthConfigurable?: boolean;
 	isSplittable?: boolean;
 };
+
+type IntrinsicComponentEvaluationFunction<
+	Spec extends CCIntrinsicComponentSpec,
+> = (
+	context: ComponentEvaluationContext,
+	nodeId: CCNodeId,
+	shape: CCIntrinsicComponentShape<Spec>,
+	config: Spec["config"],
+) => boolean;
+
 type Props<Spec extends CCIntrinsicComponentSpec> = {
 	type: CCIntrinsicComponentType;
 	name: string;
 	in: Record<Spec["in"], IntrinsicComponentPinAttributes<Spec>>;
 	out: Record<Spec["out"], IntrinsicComponentPinAttributes<Spec>>;
 	initialConfig: Spec["config"];
-	evaluate: (
-		context: ComponentEvaluationContext,
-		nodeId: CCNodeId,
-		shape: CCIntrinsicComponentShape<Spec>,
-	) => boolean; // returns whether evaluation succeeded
+	evaluate: IntrinsicComponentEvaluationFunction<Spec>;
 };
 export class IntrinsicComponentDefinition<
 	Spec extends CCIntrinsicComponentSpec = CCIntrinsicComponentSpec,
@@ -71,11 +77,7 @@ export class IntrinsicComponentDefinition<
 	readonly inputPin: Record<Spec["in"], CCComponentPin>;
 	readonly outputPin: Record<Spec["out"], CCComponentPin>;
 	readonly initialConfig: Spec["config"];
-	readonly evaluate: (
-		context: ComponentEvaluationContext,
-		nodeId: CCNodeId,
-		shape: CCIntrinsicComponentShape<Spec>,
-	) => boolean;
+	readonly evaluate: IntrinsicComponentEvaluationFunction<Spec>;
 
 	private static _lastIndex = 0;
 

--- a/src/store/intrinsics/base.ts
+++ b/src/store/intrinsics/base.ts
@@ -29,12 +29,20 @@ export type Context = {
 	componentId: CCComponentId;
 };
 
+/**
+ * How the bit width of an intrinsic component pin is determined.
+ * - `inferred` — inferred from the pins it is transitively connected to.
+ * - `calculated` — derived from the config of the node and the bit widths manually
+ *   specified for its pins, so it can only be resolved for a concrete node.
+ * - `configurable` — specified manually by the user on each node pin. `isSplittable`
+ *   tells whether the pin may be split into multiple node pins.
+ */
 type IntrinsicComponentPinBitWidthPolicy<
 	Spec extends CCIntrinsicComponentSpec,
 > =
 	| { type: "inferred" }
 	| {
-			type: "fixed";
+			type: "calculated";
 			calculateBitWidth: (
 				config: Spec["config"],
 				manualBitWidths: Partial<Record<Spec["in" | "out"], number[]>>,
@@ -45,9 +53,14 @@ type IntrinsicComponentPinBitWidthPolicy<
 type IntrinsicComponentPinAttributes<Spec extends CCIntrinsicComponentSpec> = {
 	name: string;
 	bitWidthPolicy: IntrinsicComponentPinBitWidthPolicy<Spec>;
-	isBitWidthConfigurable?: boolean;
-	isSplittable?: boolean;
 };
+
+/**
+ * The attributes of an intrinsic component pin, along with the `key` identifying it
+ * within its component definition (e.g. `In`, `Out`, `Pixels`).
+ */
+export type RegisteredIntrinsicComponentPinAttributes =
+	IntrinsicComponentPinAttributes<CCIntrinsicComponentSpec> & { key: string };
 type Props<Spec extends CCIntrinsicComponentSpec> = {
 	type: CCIntrinsicComponentType;
 	name: string;
@@ -101,39 +114,34 @@ export class IntrinsicComponentDefinition<
 		IntrinsicComponentDefinition._byId.set(this.id, this);
 		this.evaluate = props.evaluate;
 
-		this.inputPin = mapValues(props.in, (attributes) => {
-			const pin: CCComponentPin = {
-				id: this._generateId() as CCComponentPinId,
-				componentId: this.id,
-				type: "input",
-				implementation: null,
-				order: this._lastLocalIndex++,
-				name: attributes.name,
-			};
-			IntrinsicComponentDefinition._pinAttributesByPinId.set(
-				pin.id,
-				attributes as IntrinsicComponentPinAttributes<CCIntrinsicComponentSpec>,
-			);
-			this.allPins.push(pin);
-			return pin;
-		});
-		this.outputPin = mapValues(props.out, (attributes) => {
-			const pin: CCComponentPin = {
-				id: this._generateId() as CCComponentPinId,
-				componentId: this.id,
-				type: "output",
-				implementation: null,
-				order: this._lastLocalIndex++,
-				name: attributes.name,
-			};
-			IntrinsicComponentDefinition._pinAttributesByPinId.set(
-				pin.id,
-				attributes as IntrinsicComponentPinAttributes<CCIntrinsicComponentSpec>,
-			);
-			this.allPins.push(pin);
-			return pin;
-		});
+		this.inputPin = mapValues(props.in, (attributes, key) =>
+			this._registerPin("input", key, attributes),
+		);
+		this.outputPin = mapValues(props.out, (attributes, key) =>
+			this._registerPin("output", key, attributes),
+		);
 		this.initialConfig = props.initialConfig;
+	}
+
+	private _registerPin(
+		type: CCComponentPin["type"],
+		key: string,
+		attributes: IntrinsicComponentPinAttributes<Spec>,
+	): CCComponentPin {
+		const pin: CCComponentPin = {
+			id: this._generateId() as CCComponentPinId,
+			componentId: this.id,
+			type,
+			implementation: null,
+			order: this._lastLocalIndex++,
+			name: attributes.name,
+		};
+		IntrinsicComponentDefinition._pinAttributesByPinId.set(pin.id, {
+			...(attributes as IntrinsicComponentPinAttributes<CCIntrinsicComponentSpec>),
+			key,
+		});
+		this.allPins.push(pin);
+		return pin;
 	}
 
 	private static _byId: Map<CCComponentId, IntrinsicComponentDefinition> =
@@ -144,8 +152,9 @@ export class IntrinsicComponentDefinition<
 
 	private static _pinAttributesByPinId: Map<
 		CCComponentPinId,
-		IntrinsicComponentPinAttributes<CCIntrinsicComponentSpec>
+		RegisteredIntrinsicComponentPinAttributes
 	> = new Map();
+	/** @returns the attributes of the pin, or null if it is not an intrinsic component pin */
 	static getPinAttributesByPinId(pinId: CCComponentPinId) {
 		return (
 			IntrinsicComponentDefinition._pinAttributesByPinId.get(pinId) ?? null

--- a/src/store/intrinsics/definitions.ts
+++ b/src/store/intrinsics/definitions.ts
@@ -187,15 +187,13 @@ export const aggregate =
 			In: {
 				name: "In",
 				bitWidthPolicy: { type: "configurable", isSplittable: true },
-				isBitWidthConfigurable: true,
-				isSplittable: true,
 			},
 		},
 		out: {
 			Out: {
 				name: "Out",
 				bitWidthPolicy: {
-					type: "fixed",
+					type: "calculated",
 					calculateBitWidth: (_, manualBitWidths) =>
 						manualBitWidths?.In?.reduce((sum, bitWidth) => sum + bitWidth, 0) ??
 						1,
@@ -229,7 +227,7 @@ export const decompose =
 			In: {
 				name: "In",
 				bitWidthPolicy: {
-					type: "fixed",
+					type: "calculated",
 					calculateBitWidth: (_, manualBitWidths) =>
 						manualBitWidths?.Out?.reduce(
 							(sum, bitWidth) => sum + bitWidth,
@@ -242,8 +240,6 @@ export const decompose =
 			Out: {
 				name: "Out",
 				bitWidthPolicy: { type: "configurable", isSplittable: true },
-				isBitWidthConfigurable: true,
-				isSplittable: true,
 			},
 		},
 		initialConfig: null,
@@ -275,14 +271,13 @@ export const broadcast =
 		in: {
 			In: {
 				name: "In",
-				bitWidthPolicy: { type: "fixed", calculateBitWidth: () => 1 },
+				bitWidthPolicy: { type: "calculated", calculateBitWidth: () => 1 },
 			},
 		},
 		out: {
 			Out: {
 				name: "Out",
 				bitWidthPolicy: { type: "configurable", isSplittable: false },
-				isBitWidthConfigurable: true,
 			},
 		},
 		initialConfig: null,
@@ -342,7 +337,7 @@ export const display =
 			Pixels: {
 				name: "Pixels",
 				bitWidthPolicy: {
-					type: "fixed",
+					type: "calculated",
 					calculateBitWidth: (config) =>
 						config.resolution.x * config.resolution.y,
 				},

--- a/src/store/intrinsics/definitions.ts
+++ b/src/store/intrinsics/definitions.ts
@@ -5,6 +5,7 @@ import type { CCComponentPinId } from "../componentPin";
 import { IntrinsicComponentDefinition } from "./base";
 import {
 	type CCIntrinsicComponentBinaryOperatorSpec,
+	type CCIntrinsicComponentConstSpec,
 	type CCIntrinsicComponentDisplaySpec,
 	type CCIntrinsicComponentInputSpec,
 	type CCIntrinsicComponentNullaryOperatorSpec,
@@ -320,7 +321,6 @@ export const flipflop =
 			const outputShape = shape.outputShape.Out;
 			invariant(outputShape[0] && !outputShape[1]);
 			const nodePinIdToValue = context.currentFrame.nodes.get(nodeId)?.pins;
-			console.log("FlipFlop evaluate", { nodeId, inputShape, outputShape });
 			const previousValue =
 				context.previousFrame?.nodes
 					.get(nodeId)
@@ -353,6 +353,31 @@ export const display =
 		evaluate: () => true,
 	});
 
+export const const_ =
+	new IntrinsicComponentDefinition<CCIntrinsicComponentConstSpec>({
+		type: ccIntrinsicComponentTypes.CONST,
+		name: "Const",
+		in: {},
+		out: {
+			Out: {
+				name: "Out",
+				bitWidthPolicy: {
+					type: "fixed",
+					calculateBitWidth: (config) => config.data.length,
+				},
+			},
+		},
+		initialConfig: { data: new Array(8).fill(false) },
+		evaluate: (context, nodeId, shape, config) => {
+			const outputShape = shape.outputShape.Out;
+			invariant(outputShape[0] && !outputShape[1]);
+			const nodePinIdToValue = context.currentFrame.nodes.get(nodeId)?.pins;
+			if (!nodePinIdToValue) return false;
+			nodePinIdToValue.set(outputShape[0].nodePinId, config.data);
+			return true;
+		},
+	});
+
 export const definitions: {
 	[t in CCIntrinsicComponentType]: IntrinsicComponentDefinition<
 		CCIntrinsicComponentSpecByType[t]
@@ -369,6 +394,7 @@ export const definitions: {
 	[ccIntrinsicComponentTypes.BROADCAST]: broadcast,
 	[ccIntrinsicComponentTypes.FLIPFLOP]: flipflop,
 	[ccIntrinsicComponentTypes.DISPLAY]: display,
+	[ccIntrinsicComponentTypes.CONST]: const_,
 	[ccIntrinsicComponentTypes.TRUE]: true_,
 	[ccIntrinsicComponentTypes.FALSE]: false_,
 };
@@ -376,13 +402,21 @@ export const definitions: {
 export const definitionByComponentId = new Map<
 	CCComponentId,
 	IntrinsicComponentDefinition
->(Object.values(definitions).map((definition) => [definition.id, definition]));
+>(
+	Object.values(definitions).map((definition) => [
+		definition.id,
+		definition as IntrinsicComponentDefinition,
+	]),
+);
 
 export const definitionByComponentPinId = new Map<
 	CCComponentPinId,
 	IntrinsicComponentDefinition
 >(
 	Object.values(definitions).flatMap((definition) =>
-		definition.allPins.map((pin) => [pin.id, definition]),
+		definition.allPins.map((pin) => [
+			pin.id,
+			definition as IntrinsicComponentDefinition,
+		]),
 	),
 );

--- a/src/store/intrinsics/definitions.ts
+++ b/src/store/intrinsics/definitions.ts
@@ -357,7 +357,7 @@ export const const_ =
 			Out: {
 				name: "Out",
 				bitWidthPolicy: {
-					type: "fixed",
+					type: "calculated",
 					calculateBitWidth: (config) => config.data.length,
 				},
 			},

--- a/src/store/intrinsics/types.ts
+++ b/src/store/intrinsics/types.ts
@@ -1,5 +1,6 @@
 import type { JsonValue } from "type-fest";
 import type { Vector2 } from "../../common/vector2";
+import type { SimulationValue } from "../simulation";
 
 export const ccIntrinsicComponentTypes = {
 	AND: "AND",
@@ -13,6 +14,7 @@ export const ccIntrinsicComponentTypes = {
 	DECOMPOSE: "DECOMPOSE",
 	FLIPFLOP: "FLIPFLOP",
 	DISPLAY: "DISPLAY",
+	CONST: "CONST",
 	TRUE: "TRUE",
 	FALSE: "FALSE",
 } as const;
@@ -60,6 +62,12 @@ export type CCIntrinsicComponentDisplaySpec = {
 	config: { resolution: Vector2 };
 };
 
+export type CCIntrinsicComponentConstSpec = {
+	in: never;
+	out: "Out";
+	config: { data: SimulationValue };
+};
+
 export type CCIntrinsicComponentSpecByType = {
 	[ccIntrinsicComponentTypes.AND]: CCIntrinsicComponentBinaryOperatorSpec;
 	[ccIntrinsicComponentTypes.OR]: CCIntrinsicComponentBinaryOperatorSpec;
@@ -72,6 +80,7 @@ export type CCIntrinsicComponentSpecByType = {
 	[ccIntrinsicComponentTypes.BROADCAST]: CCIntrinsicComponentUnaryOperatorSpec;
 	[ccIntrinsicComponentTypes.FLIPFLOP]: CCIntrinsicComponentUnaryOperatorSpec;
 	[ccIntrinsicComponentTypes.DISPLAY]: CCIntrinsicComponentDisplaySpec;
+	[ccIntrinsicComponentTypes.CONST]: CCIntrinsicComponentConstSpec;
 	[ccIntrinsicComponentTypes.TRUE]: CCIntrinsicComponentNullaryOperatorSpec;
 	[ccIntrinsicComponentTypes.FALSE]: CCIntrinsicComponentNullaryOperatorSpec;
 };

--- a/src/store/node.ts
+++ b/src/store/node.ts
@@ -25,6 +25,11 @@ export type CCNodeStoreEvents = {
 	willUnregister(node: CCNode): void;
 	didUnregister(node: CCNode): void;
 	didUpdate(node: CCNode): void;
+	/**
+	 * Emitted in addition to `didUpdate` when the config of a node changed, so that
+	 * listeners depending on the config are not woken up by frequent position updates.
+	 */
+	didUpdateConfig(node: CCNode): void;
 };
 export const ccNodeStoreChangeEventTypes: (keyof CCNodeStoreEvents)[] = [
 	"didRegister",
@@ -145,6 +150,9 @@ export class CCNodeStore extends EventEmitter<CCNodeStoreEvents> {
 		const existingNode = nullthrows(this.#nodes.get(id));
 		const newNode = { ...existingNode, ...value };
 		this.#nodes.set(id, newNode);
+		if ("config" in value && value.config !== existingNode.config) {
+			this.emit("didUpdateConfig", newNode);
+		}
 		this.emit("didUpdate", newNode);
 	}
 

--- a/src/store/nodePin.test.ts
+++ b/src/store/nodePin.test.ts
@@ -1,0 +1,284 @@
+import nullthrows from "nullthrows";
+import { describe, expect, it } from "vitest";
+import CCStore from ".";
+import { type CCComponent, CCComponentStore } from "./component";
+import type { CCComponentPinId } from "./componentPin";
+import { CCConnectionStore } from "./connection";
+import type { IntrinsicComponentDefinition } from "./intrinsics/base";
+import * as intrinsics from "./intrinsics/definitions";
+import { type CCNodeId, CCNodeStore } from "./node";
+import { CCNodePinStore } from "./nodePin";
+
+function createRootStore() {
+	const store = new CCStore();
+	store.mount();
+	const rootComponent = CCComponentStore.create({ name: "Root" });
+	store.components.register(rootComponent);
+	return { store, rootComponent };
+}
+
+function registerNode(
+	store: CCStore,
+	rootComponent: CCComponent,
+	// biome-ignore lint/suspicious/noExplicitAny: the spec of the definition is irrelevant here
+	definition: IntrinsicComponentDefinition<any>,
+) {
+	const node = CCNodeStore.create({
+		parentComponentId: rootComponent.id,
+		componentId: definition.component.id,
+		position: { x: 0, y: 0 },
+	});
+	store.nodes.register(node);
+	return node;
+}
+
+function getNodePinBitWidth(
+	store: CCStore,
+	nodeId: CCNodeId,
+	componentPinId: CCComponentPinId,
+) {
+	const nodePin = nullthrows(
+		store.nodePins
+			.getManyByNodeId(nodeId)
+			.find((pin) => pin.componentPinId === componentPinId),
+	);
+	return store.nodePins.getNodePinBitWidthStatus(nodePin.id);
+}
+
+describe("Node pin store", () => {
+	describe("getNodePinBitWidthStatus", () => {
+		it("should calculate the bit width of a display pin from the config of its node", () => {
+			const { store, rootComponent } = createRootStore();
+			const displayNode = registerNode(
+				store,
+				rootComponent,
+				intrinsics.display,
+			);
+
+			expect(
+				getNodePinBitWidth(
+					store,
+					displayNode.id,
+					intrinsics.display.inputPin.Pixels.id,
+				),
+			).toEqual({ isFixed: true, bitWidth: 20 * 15 });
+
+			store.nodes.update(displayNode.id, {
+				config: { resolution: { x: 4, y: 3 } },
+			});
+
+			expect(
+				getNodePinBitWidth(
+					store,
+					displayNode.id,
+					intrinsics.display.inputPin.Pixels.id,
+				),
+			).toEqual({ isFixed: true, bitWidth: 4 * 3 });
+		});
+
+		it("should propagate the bit width of a display pin to the pins connected to it", () => {
+			const { store, rootComponent } = createRootStore();
+			const displayNode = registerNode(
+				store,
+				rootComponent,
+				intrinsics.display,
+			);
+			store.nodes.update(displayNode.id, {
+				config: { resolution: { x: 4, y: 3 } },
+			});
+			const inputNode = registerNode(store, rootComponent, intrinsics.input);
+			const inputNodePin = nullthrows(
+				store.nodePins
+					.getManyByNodeId(inputNode.id)
+					.find(
+						(pin) => pin.componentPinId === intrinsics.input.outputPin.Out.id,
+					),
+			);
+			const pixelsNodePin = nullthrows(
+				store.nodePins
+					.getManyByNodeId(displayNode.id)
+					.find(
+						(pin) =>
+							pin.componentPinId === intrinsics.display.inputPin.Pixels.id,
+					),
+			);
+			store.connections.register(
+				CCConnectionStore.create({
+					parentComponentId: rootComponent.id,
+					from: inputNodePin.id,
+					to: pixelsNodePin.id,
+					bentPortion: 0.5,
+				}),
+			);
+
+			expect(store.nodePins.getNodePinBitWidthStatus(inputNodePin.id)).toEqual({
+				isFixed: true,
+				bitWidth: 4 * 3,
+			});
+		});
+		it("should sum up the manual bit widths of the input pins of an aggregate node", () => {
+			const { store, rootComponent } = createRootStore();
+			const node = registerNode(store, rootComponent, intrinsics.aggregate);
+			const firstInputNodePin = nullthrows(
+				store.nodePins
+					.getManyByNodeId(node.id)
+					.find(
+						(pin) => pin.componentPinId === intrinsics.aggregate.inputPin.In.id,
+					),
+			);
+			store.nodePins.update(firstInputNodePin.id, { manualBitWidth: 5 });
+			store.nodePins.register(
+				CCNodePinStore.create({
+					nodeId: node.id,
+					componentPinId: intrinsics.aggregate.inputPin.In.id,
+					order: firstInputNodePin.order + 1,
+					manualBitWidth: 3,
+				}),
+			);
+
+			expect(
+				store.nodePins.getNodePinBitWidthStatus(firstInputNodePin.id),
+			).toEqual({ isFixed: true, bitWidth: 5 });
+			expect(
+				getNodePinBitWidth(
+					store,
+					node.id,
+					intrinsics.aggregate.outputPin.Out.id,
+				),
+			).toEqual({ isFixed: true, bitWidth: 8 });
+		});
+
+		it("should sum up the manual bit widths of the output pins of a decompose node", () => {
+			const { store, rootComponent } = createRootStore();
+			const node = registerNode(store, rootComponent, intrinsics.decompose);
+			const firstOutputNodePin = nullthrows(
+				store.nodePins
+					.getManyByNodeId(node.id)
+					.find(
+						(pin) =>
+							pin.componentPinId === intrinsics.decompose.outputPin.Out.id,
+					),
+			);
+			store.nodePins.update(firstOutputNodePin.id, { manualBitWidth: 2 });
+			store.nodePins.register(
+				CCNodePinStore.create({
+					nodeId: node.id,
+					componentPinId: intrinsics.decompose.outputPin.Out.id,
+					order: firstOutputNodePin.order + 1,
+					manualBitWidth: 6,
+				}),
+			);
+
+			expect(
+				getNodePinBitWidth(store, node.id, intrinsics.decompose.inputPin.In.id),
+			).toEqual({ isFixed: true, bitWidth: 8 });
+		});
+
+		it("should reject a node pin of a configurable component pin without a manual bit width", () => {
+			const { store, rootComponent } = createRootStore();
+			const node = registerNode(store, rootComponent, intrinsics.broadcast);
+			const outputNodePin = nullthrows(
+				store.nodePins
+					.getManyByNodeId(node.id)
+					.find(
+						(pin) =>
+							pin.componentPinId === intrinsics.broadcast.outputPin.Out.id,
+					),
+			);
+			store.nodePins.update(outputNodePin.id, { manualBitWidth: null });
+
+			expect(() =>
+				store.nodePins.getNodePinBitWidthStatus(outputNodePin.id),
+			).toThrow(/must have a positive manual bit width/);
+		});
+
+		it("should broadcast a single bit to the manually specified bit width", () => {
+			const { store, rootComponent } = createRootStore();
+			const node = registerNode(store, rootComponent, intrinsics.broadcast);
+			const outputNodePin = nullthrows(
+				store.nodePins
+					.getManyByNodeId(node.id)
+					.find(
+						(pin) =>
+							pin.componentPinId === intrinsics.broadcast.outputPin.Out.id,
+					),
+			);
+			store.nodePins.update(outputNodePin.id, { manualBitWidth: 7 });
+
+			expect(
+				getNodePinBitWidth(store, node.id, intrinsics.broadcast.inputPin.In.id),
+			).toEqual({ isFixed: true, bitWidth: 1 });
+			expect(store.nodePins.getNodePinBitWidthStatus(outputNodePin.id)).toEqual(
+				{
+					isFixed: true,
+					bitWidth: 7,
+				},
+			);
+		});
+	});
+
+	describe("bit width consistency of connections", () => {
+		function connectBroadcastToDisplay(bitWidth: number) {
+			const { store, rootComponent } = createRootStore();
+			const displayNode = registerNode(
+				store,
+				rootComponent,
+				intrinsics.display,
+			);
+			const broadcastNode = registerNode(
+				store,
+				rootComponent,
+				intrinsics.broadcast,
+			);
+			const pixelsNodePin = nullthrows(
+				store.nodePins
+					.getManyByNodeId(displayNode.id)
+					.find(
+						(pin) =>
+							pin.componentPinId === intrinsics.display.inputPin.Pixels.id,
+					),
+			);
+			const broadcastOutNodePin = nullthrows(
+				store.nodePins
+					.getManyByNodeId(broadcastNode.id)
+					.find(
+						(pin) =>
+							pin.componentPinId === intrinsics.broadcast.outputPin.Out.id,
+					),
+			);
+			store.nodePins.update(broadcastOutNodePin.id, {
+				manualBitWidth: bitWidth,
+			});
+			store.connections.register(
+				CCConnectionStore.create({
+					parentComponentId: rootComponent.id,
+					from: broadcastOutNodePin.id,
+					to: pixelsNodePin.id,
+					bentPortion: 0.5,
+				}),
+			);
+			expect(store.connections.getMany()).toHaveLength(1);
+			return { store, displayNode };
+		}
+
+		it("should drop the connections that a display config change makes inconsistent", () => {
+			const { store, displayNode } = connectBroadcastToDisplay(20 * 15);
+
+			store.nodes.update(displayNode.id, {
+				config: { resolution: { x: 4, y: 3 } },
+			});
+
+			expect(store.connections.getMany()).toHaveLength(0);
+		});
+
+		it("should keep the connections that stay consistent across a display config change", () => {
+			const { store, displayNode } = connectBroadcastToDisplay(20 * 15);
+
+			store.nodes.update(displayNode.id, {
+				config: { resolution: { x: 15, y: 20 } },
+			});
+
+			expect(store.connections.getMany()).toHaveLength(1);
+		});
+	});
+});

--- a/src/store/nodePin.ts
+++ b/src/store/nodePin.ts
@@ -37,6 +37,12 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 
 	#markedAsDeleted: Set<CCNodePinId> = new Set();
 
+	#bitWidthCache: Map<CCNodePinId, CCNodePinBitWidthStatus> = new Map();
+
+	#clearBitWidthCache(): void {
+		this.#bitWidthCache.clear();
+	}
+
 	/**
 	 * Constructor of CCNodePinStore
 	 * @param store store
@@ -54,6 +60,10 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 	}
 
 	mount() {
+		this.#store.connections.on("didRegister", () => this.#clearBitWidthCache());
+		this.#store.connections.on("didUnregister", () =>
+			this.#clearBitWidthCache(),
+		);
 		this.#store.nodes.on("didRegister", (node) => {
 			const componentPins = this.#store.componentPins.getManyByComponentId(
 				node.componentId,
@@ -105,6 +115,7 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 		invariant(this.#store.componentPins.get(nodePin.componentPinId));
 		invariant(this.#store.nodes.get(nodePin.nodeId));
 		this.#nodePins.set(nodePin.id, nodePin);
+		this.#clearBitWidthCache();
 		this.emit("didRegister", nodePin);
 	}
 
@@ -119,6 +130,7 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 			this.emit("willUnregister", nodePin);
 			this.#nodePins.delete(nodePin.id);
 		});
+		this.#clearBitWidthCache();
 		this.emit("didUnregister", nodePin);
 		this.#markedAsDeleted.delete(id);
 	}
@@ -127,6 +139,7 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 		const existingNodePin = nullthrows(this.#nodePins.get(id));
 		const newNodePin = { ...existingNodePin, ...value };
 		this.#nodePins.set(id, newNodePin);
+		this.#clearBitWidthCache();
 		this.emit("didUpdate", newNodePin);
 	}
 
@@ -181,6 +194,8 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 	 * @returns bit width status of the pin
 	 */
 	getNodePinBitWidthStatus(nodePinId: CCNodePinId): CCNodePinBitWidthStatus {
+		const cached = this.#bitWidthCache.get(nodePinId);
+		if (cached) return cached;
 		const traverseNodePinBitWidthStatus = (
 			targetNodePinId: CCNodePinId,
 			seen: Set<CCNodeId>,
@@ -294,7 +309,9 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 			}
 			return givenComponentPinBitWidthStatus;
 		};
-		return traverseNodePinBitWidthStatus(nodePinId, new Set());
+		const result = traverseNodePinBitWidthStatus(nodePinId, new Set());
+		this.#bitWidthCache.set(nodePinId, result);
+		return result;
 	}
 
 	isMarkedAsDeleted(id: CCNodePinId) {

--- a/src/store/nodePin.ts
+++ b/src/store/nodePin.ts
@@ -5,7 +5,6 @@ import type { Opaque } from "type-fest";
 import type CCStore from ".";
 import type { CCComponentPinId, CCNodePinBitWidthStatus } from "./componentPin";
 import { IntrinsicComponentDefinition } from "./intrinsics/base";
-import { aggregate, broadcast, decompose } from "./intrinsics/definitions";
 import type { CCNodeId } from "./node";
 
 export type CCNodePinId = Opaque<string, "CCNodePinId">;
@@ -64,6 +63,8 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 		this.#store.connections.on("didUnregister", () =>
 			this.#clearBitWidthCache(),
 		);
+		// A calculated bit width may be derived from the config of its node
+		this.#store.nodes.on("didUpdateConfig", () => this.#clearBitWidthCache());
 		this.#store.nodes.on("didRegister", (node) => {
 			const componentPins = this.#store.componentPins.getManyByComponentId(
 				node.componentId,
@@ -187,6 +188,38 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 		);
 	}
 
+	static #requireManualBitWidth(nodePin: CCNodePin): number {
+		invariant(
+			nodePin.manualBitWidth !== null && nodePin.manualBitWidth > 0,
+			`Node pin ${nodePin.id} of a configurable component pin must have a positive manual bit width, but got ${nodePin.manualBitWidth}`,
+		);
+		return nodePin.manualBitWidth;
+	}
+
+	/**
+	 * Collect the manually specified bit widths of the pins of a single node, grouped by
+	 * the pin key of its intrinsic component definition (e.g. `In`, `Out`) and ordered by
+	 * the order of the node pins.
+	 * @param nodePins all pins of one node
+	 * @returns the bit widths of the pins of configurable component pins
+	 */
+	static #collectManualBitWidths(
+		nodePins: CCNodePin[],
+	): Partial<Record<string, number[]>> {
+		const manualBitWidths: Partial<Record<string, number[]>> = {};
+		for (const nodePin of nodePins.toSorted((a, b) => a.order - b.order)) {
+			const attributes = IntrinsicComponentDefinition.getPinAttributesByPinId(
+				nodePin.componentPinId,
+			);
+			// Only a configurable pin carries a manual bit width; the others are null
+			if (attributes?.bitWidthPolicy.type !== "configurable") continue;
+			const bitWidths = manualBitWidths[attributes.key] ?? [];
+			bitWidths.push(CCNodePinStore.#requireManualBitWidth(nodePin));
+			manualBitWidths[attributes.key] = bitWidths;
+		}
+		return manualBitWidths;
+	}
+
 	/**
 	 * Get the bit width status of a node pin
 	 * @param pinId id of pin
@@ -200,97 +233,73 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 			targetNodePinId: CCNodePinId,
 			seen: Set<CCNodeId>,
 		): CCNodePinBitWidthStatus => {
-			const {
-				nodeId: targetNodeId,
-				componentPinId: targetComponentPinId,
-				manualBitWidth,
-			} = nullthrows(this.get(targetNodePinId));
+			const targetNodePin = nullthrows(this.get(targetNodePinId));
+			const { nodeId: targetNodeId, componentPinId: targetComponentPinId } =
+				targetNodePin;
 
 			seen.add(targetNodeId);
 			const targetNode = nullthrows(this.#store.nodes.get(targetNodeId));
 			const targetNodePins = this.getManyByNodeId(targetNode.id);
-			const givenComponentPinBitWidthStatus =
-				this.#store.componentPins.getComponentPinBitWidthStatus(
+			const attributes =
+				IntrinsicComponentDefinition.getPinAttributesByPinId(
 					targetComponentPinId,
 				);
-			if (givenComponentPinBitWidthStatus.isFixed) {
-				return givenComponentPinBitWidthStatus;
-			}
-			if (givenComponentPinBitWidthStatus.fixMode === "manual") {
-				const componentPin =
-					this.#store.componentPins.get(targetComponentPinId);
-				invariant(componentPin);
-				switch (componentPin.id) {
-					case nullthrows(aggregate.inputPin.In.id):
-					case nullthrows(broadcast.outputPin.Out.id):
-					case nullthrows(decompose.outputPin.Out.id):
-						invariant(
-							manualBitWidth,
-							"aggregate inputPin, broadcast outputPin, or decompose outputPin must have a manual bit width",
-						);
+			if (attributes) {
+				switch (attributes.bitWidthPolicy.type) {
+					case "configurable":
 						return {
 							isFixed: true,
-							bitWidth: manualBitWidth,
+							bitWidth: CCNodePinStore.#requireManualBitWidth(targetNodePin),
 						};
-					case nullthrows(aggregate.outputPin.Out.id): {
-						const bitWidth = targetNodePins
-							.filter((pin) => {
-								const componentPin = this.#store.componentPins.get(
-									pin.componentPinId,
-								);
-								invariant(componentPin);
-								return componentPin.type === "input";
-							})
-							.reduce((acc, pin) => {
-								invariant(pin.manualBitWidth);
-								return acc + pin.manualBitWidth;
-							}, 0);
+					case "calculated":
 						return {
 							isFixed: true,
-							bitWidth,
+							bitWidth: attributes.bitWidthPolicy.calculateBitWidth(
+								targetNode.config,
+								CCNodePinStore.#collectManualBitWidths(targetNodePins),
+							),
 						};
-					}
-					case nullthrows(decompose.inputPin.In.id): {
-						const bitWidth = targetNodePins
-							.filter((pin) => {
-								const componentPin = this.#store.componentPins.get(
-									pin.componentPinId,
-								);
-								invariant(componentPin);
-								return componentPin.type === "output";
-							})
-							.reduce((acc, pin) => {
-								invariant(pin.manualBitWidth);
-								return acc + pin.manualBitWidth;
-							}, 0);
-						return {
-							isFixed: true,
-							bitWidth,
-						};
-					}
+					case "inferred":
+						// Resolved from the pins it is connected to, below
+						break;
 					default:
 						throw new Error(
-							`Bit width status of ${componentPin.id} is undecidable`,
+							`Unknown bit width policy: ${attributes.bitWidthPolicy satisfies never}`,
 						);
 				}
-			}
-			for (const targetNodePin of targetNodePins) {
-				const targetComponentPinBitWidthStatus =
+			} else {
+				// A user defined component pin is fixed by the implementation of its component
+				const componentPinBitWidthStatus =
 					this.#store.componentPins.getComponentPinBitWidthStatus(
-						targetNodePin.componentPinId,
+						targetComponentPinId,
 					);
-				if (targetComponentPinBitWidthStatus.isFixed) {
+				if (componentPinBitWidthStatus.isFixed) {
+					return componentPinBitWidthStatus;
+				}
+			}
+			// The bit width of an inferred pin is shared with the other inferred pins of its
+			// node, so any of them may be the one that is connected to a pin of a known width.
+			for (const siblingNodePin of targetNodePins) {
+				const siblingComponentPinBitWidthStatus =
+					this.#store.componentPins.getComponentPinBitWidthStatus(
+						siblingNodePin.componentPinId,
+					);
+				if (siblingComponentPinBitWidthStatus.isFixed) {
 					continue;
 				}
-				if (targetComponentPinBitWidthStatus.fixMode === "manual") {
-					throw new Error("unreachable");
+				if (siblingComponentPinBitWidthStatus.fixMode === "nodeDependent") {
+					// The bit width of a node dependent pin never propagates to its sibling
+					// pins, so no intrinsic component mixes it with inferred pins.
+					throw new Error(
+						`Component pin ${siblingNodePin.componentPinId} must not mix a node dependent bit width with inferred sibling pins`,
+					);
 				}
 				const connections = nullthrows(
-					this.#store.connections.getConnectionsByNodePinId(targetNodePin.id),
+					this.#store.connections.getConnectionsByNodePinId(siblingNodePin.id),
 				);
 				for (const connection of connections) {
 					const componentPin = nullthrows(
-						this.#store.componentPins.get(targetNodePin.componentPinId),
+						this.#store.componentPins.get(siblingNodePin.componentPinId),
 					);
 					const connectedNodePinId =
 						componentPin.type === "input" ? connection.from : connection.to;
@@ -307,7 +316,7 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 					}
 				}
 			}
-			return givenComponentPinBitWidthStatus;
+			return { isFixed: false };
 		};
 		const result = traverseNodePinBitWidthStatus(nodePinId, new Set());
 		this.#bitWidthCache.set(nodePinId, result);
@@ -374,15 +383,27 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 			console.warn(`Input pin already has a connection: ${bNodePin.id}`);
 			return false;
 		}
-		const aBitWidthStatus = this.getNodePinBitWidthStatus(a);
-		const bBitWidthStatus = this.getNodePinBitWidthStatus(b);
-		if (aBitWidthStatus.isFixed && bBitWidthStatus.isFixed) {
+		if (!this.hasCompatibleBitWidths(a, b)) {
 			console.warn(
-				`Cannot connect pins with fixed bit width: ${aNodePin.id} and ${bNodePin.id}`,
+				`Cannot connect pins with conflicting bit widths: ${aNodePin.id} and ${bNodePin.id}`,
 			);
-			return aBitWidthStatus.bitWidth === bBitWidthStatus.bitWidth;
+			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Check whether two node pins can carry the same value. A pin whose bit width is not
+	 * fixed yet adapts to the pin it is connected to, so it is compatible with any pin.
+	 * @param a id of a pin
+	 * @param b id of the other pin
+	 * @returns whether the bit widths of the two pins do not conflict
+	 */
+	hasCompatibleBitWidths(a: CCNodePinId, b: CCNodePinId): boolean {
+		const aBitWidthStatus = this.getNodePinBitWidthStatus(a);
+		const bBitWidthStatus = this.getNodePinBitWidthStatus(b);
+		if (!aBitWidthStatus.isFixed || !bBitWidthStatus.isFixed) return true;
+		return aBitWidthStatus.bitWidth === bBitWidthStatus.bitWidth;
 	}
 
 	/**
@@ -402,7 +423,7 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 			id: crypto.randomUUID() as CCNodePinId,
 			manualBitWidth:
 				partialPin.manualBitWidth ??
-				(attributes?.isBitWidthConfigurable ? 1 : null),
+				(attributes?.bitWidthPolicy.type === "configurable" ? 1 : null),
 		};
 	}
 

--- a/src/store/nodePin.ts
+++ b/src/store/nodePin.ts
@@ -380,6 +380,8 @@ export class CCNodePinStore extends EventEmitter<CCNodePinStoreEvents> {
 			console.warn(
 				`Cannot connect pins with fixed bit width: ${aNodePin.id} and ${bNodePin.id}`,
 			);
+			console.log(`Bit width of ${aNodePin.id}: ${aBitWidthStatus.bitWidth}`);
+			console.log(`Bit width of ${bNodePin.id}: ${bBitWidthStatus.bitWidth}`);
 			return aBitWidthStatus.bitWidth === bBitWidthStatus.bitWidth;
 		}
 		return true;

--- a/src/store/react/selectors.ts
+++ b/src/store/react/selectors.ts
@@ -1,7 +1,11 @@
 import memoizeOne from "memoize-one";
 import nullthrows from "nullthrows";
 import { useCallback, useMemo, useSyncExternalStore } from "react";
-import type { CCComponent, CCComponentId } from "../component";
+import {
+	type CCComponent,
+	type CCComponentId,
+	isEachInputPinConnected,
+} from "../component";
 import type { CCComponentPin } from "../componentPin";
 import type { CCNode, CCNodeId } from "../node";
 import type { CCNodePin } from "../nodePin";
@@ -182,6 +186,40 @@ export function useNodePins(nodeId: CCNodeId) {
 			};
 		},
 		[store, nodeId],
+	);
+	return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+export function useCanSimulate(componentId: CCComponentId) {
+	const { store } = useStore();
+	const getSnapshot = useCallback(
+		() => isEachInputPinConnected(store, componentId),
+		[store, componentId],
+	);
+	const subscribe = useCallback(
+		(onStoreChange: () => void) => {
+			store.nodes.on("didRegister", onStoreChange);
+			store.nodes.on("didUnregister", onStoreChange);
+			store.nodePins.on("didRegister", onStoreChange);
+			store.nodePins.on("didUnregister", onStoreChange);
+			store.componentPins.on("didRegister", onStoreChange);
+			store.componentPins.on("didUpdate", onStoreChange);
+			store.componentPins.on("didUnregister", onStoreChange);
+			store.connections.on("didRegister", onStoreChange);
+			store.connections.on("didUnregister", onStoreChange);
+			return () => {
+				store.nodes.off("didRegister", onStoreChange);
+				store.nodes.off("didUnregister", onStoreChange);
+				store.nodePins.off("didRegister", onStoreChange);
+				store.nodePins.off("didUnregister", onStoreChange);
+				store.componentPins.off("didRegister", onStoreChange);
+				store.componentPins.off("didUpdate", onStoreChange);
+				store.componentPins.off("didUnregister", onStoreChange);
+				store.connections.off("didRegister", onStoreChange);
+				store.connections.off("didUnregister", onStoreChange);
+			};
+		},
+		[store],
 	);
 	return useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/src/store/simulation.ts
+++ b/src/store/simulation.ts
@@ -100,7 +100,7 @@ function simulateIntrinsic(
 	const componentDefinition = definitionByComponentId.get(componentId);
 	invariant(componentDefinition);
 	const shape = createIntrinsicComponentShape(store, nodeId, context);
-	return componentDefinition.evaluate(context, nodeId, shape);
+	return componentDefinition.evaluate(context, nodeId, shape, node.config);
 }
 
 function simulateNode(


### PR DESCRIPTION
Rework the node renderer around a layout → geometry two-step, generalize bit width handling around per-pin policies, and build on both to add a Const intrinsic component, display config editing, and play-mode guards.

## Renderer: layout → geometry split
- Layout / LayoutSource types split out from Geometry: a layout is a size plus relative pin offsets (`nodePinOffsetById`), and `ccComponentEditorRendererLayoutToGeometry` turns it into absolute positions
- Node SVG wrapper switched from `<g>` to `<svg>` so child renderers draw in local coordinates and can use percentage dimensions (Default uses `width="100%"`)
- Display layout now scales with `config.resolution` and shares its constants with the renderer; pixel fill indexes `inputValue` in row-major order (fixes the previously reversed pixel order)
- Display nodes get a working config settings popover (`ConfigSettingButton`) for editing the resolution, and now compose the Default renderer for their frame

## New Const intrinsic component
- New `CONST` type with `config: { data: SimulationValue }`; the output bit width is calculated from `config.data.length` and `evaluate` writes the configured data to the output pin
- Dedicated renderer and layout calculator (the renderer currently shows placeholder random data instead of `config.data`)
- Intrinsic `evaluate` functions now receive the node config as a fourth argument

## Bit width policy refactor
- The `fixed` policy is renamed to `calculated`, and `isBitWidthConfigurable` / `isSplittable` are folded into the `configurable` policy
- `CCComponentPinBitWidthStatus` fixMode `manual` is replaced by `nodeDependent`: such widths come from a node's config and/or manually specified pin widths, so they can only be resolved per node
- `getNodePinBitWidthStatus` is rewritten to be policy-driven — the hard-coded special cases for aggregate / decompose / broadcast pins are gone; manual bit widths are collected per pin key and fed to `calculateBitWidth`
- Bit width results are cached in `CCNodePinStore`, invalidated on node pin / connection changes and on node config updates (new `didUpdateConfig` event on the node store)
- New `hasCompatibleBitWidths` helper used by `isConnectable`; connections that a config change makes inconsistent (e.g. changing a display resolution) are dropped, and existing connections are re-validated when a new one is registered
- New unit tests in `nodePin.test.ts` covering bit width resolution (input / display / aggregate / decompose / broadcast) and connection consistency across config changes

## Play mode & simulation
- `isEachInputPinConnected` utility and `useCanSimulate` hook disable the ViewModeSwitcher play button while any input pin is unconnected
- `executeSimulation` decoupled from raw node / connection store events in the core slice
- Input values are keyed by `{ componentPinId, timeStep }` objects with explicit serialization instead of `JSON.stringify` of a tuple; initial values derive their bit width from the pin's implementation node pin
